### PR TITLE
escape mysql column name with `

### DIFF
--- a/include/model.hrl
+++ b/include/model.hrl
@@ -63,8 +63,6 @@ create() -> create(#?MODULE{}).
 create(Record = #?MODULE{}) ->
   Now = {datetime, calendar:universal_time()},
   RecordToInsert = Record#?MODULE{created_at = Now, updated_at = Now},
-  PH = insert_query(map_row(RecordToInsert, dump)),
-  io:format("~n~n Insert query ~p", [PH]),
   Id = db:insert(insert_query(map_row(RecordToInsert, dump))),
   RecordToInsert#?MODULE{id = Id}.
 


### PR DESCRIPTION
There is a bug when trying to update  fields like "key, password, ...". The update function does not escape the field name.
